### PR TITLE
feat: Add `--current` flag to pick up the current branch to be used in the deployment - add protected pipeline and branch to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $ gobuddy config get
 Current Configuration:
 Token: a-valid-token
 Workspace: fizzbuzz
+Protected Branch: master
+Protected Pipeline: Deploy to Production
 ```
 
 **`set`** (if one does not exist)
@@ -50,6 +52,8 @@ $ gobuddy config set
 
 Enter your Buddy API token: ********
 Enter your Buddy workspace: foobar
+Enter the branch you want to protect: some-branch
+Enter the pipeline you want to protect: some-pipeline
 ```
 
 **`set <key> <value>`**
@@ -57,6 +61,8 @@ Enter your Buddy workspace: foobar
 One of:
 - `token`
 - `workspace`
+- `protected_branch`
+- `protected_pipeline`
 
 ```bash
 $ gobuddy config set token some-value
@@ -90,6 +96,8 @@ This command allows you to trigger a deployment pipeline for your project using 
 | `<project>` | `argument` | Pass the project name (repo) you want to deploy  |`false`|
 | `-b or --branch` |`flag`| Pass this flag followed by a value if you want to specify your own git branch | `false`|
 |`-p or --pipeline`|`flag`| Pass this flag followed by a value if you want to specify your own pipeline ID |`false`|
+|`-c or --current`|`flag`| Pass this flag if you want to use the current branch of the directory |`false`|
+
 
 #### Interactive
 If you don’t pass all arguments and flags, Go Buddy will pick up where you left off and guide you through some interactive steps:
@@ -115,7 +123,7 @@ $ gobuddy deploy project-foobar -b fizz-buzz
 
 **Running with all flags passed**
 ```bash
-$ gobuddy deploy project-foobar -b fizz-buzz -p 12345
+$ gobuddy deploy project-foobar -c -b fizz-buzz -p 12345
 ```
 
 ### Check Pipeline Status

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	buddy "github.com/JacobAndrewSmith92/gobuddy/internal"
+	"github.com/JacobAndrewSmith92/gobuddy/internal/util"
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
@@ -18,6 +19,7 @@ import (
 
 var branchFlag string
 var pipelineFlag string
+var currentFlag bool
 
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
@@ -39,6 +41,14 @@ var deployCmd = &cobra.Command{
 			log.Fatalf("Error creating api client: %v", err)
 		}
 
+		if currentFlag {
+			branch, err = util.GetBranch()
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			log.Printf("Using current branch: %s\n", branch)
+		}
+
 		if len(args) > 0 {
 			project = args[0]
 			fmt.Printf("Looking up project passed as argument: %s\n", project)
@@ -56,16 +66,18 @@ var deployCmd = &cobra.Command{
 			project = searchProject(projects)
 		}
 
-		if branchFlag != "" {
-			branch = branchFlag
-			fmt.Printf("Looking up branch passed as flag: %s\n", branch)
+		if branchFlag != "" || currentFlag {
+			if branch == "" {
+				branch = branchFlag
+			}
+			fmt.Printf("Looking up branch: %s\n", branch)
 			branchFound, err := apiClient.FetchBranchByName(project, branch)
 			if err != nil {
-				log.Fatalf("Error: %v", err)
+				log.Fatalf("Error: %v", err.Errors)
 			}
 			log.Println("Branch found.", branchFound.Name)
 			branch = branchFound.Name
-		} else {
+		} else if branch == "" {
 			branches, err := apiClient.FetchBranches(project)
 			if err != nil {
 				log.Fatalf("Error fetching branches: %v", err)
@@ -90,9 +102,13 @@ var deployCmd = &cobra.Command{
 			pipeline = searchPipeline(pipelines, branch)
 		}
 
-		if pipeline.Name == "CD" && branch != "master" {
+		if pipeline.Name == config.Protected.Pipeline {
 			red := color.New(color.FgRed).SprintFunc()
-			fmt.Println(red("Error: Only the 'master' branch can be deployed to the production pipeline."))
+			log.Fatalf(red("Error: Unable to deploy protected pipeline: %s"), config.Protected.Pipeline)
+			return
+		} else if branch == config.Protected.Branch {
+			red := color.New(color.FgRed).SprintFunc()
+			log.Fatalf(red("Error: Unable to deploy protected branch: %s"), config.Protected.Branch)
 			return
 		}
 
@@ -163,7 +179,7 @@ func init() {
 	// Add branch and pipeline flags
 	deployCmd.Flags().StringVarP(&branchFlag, "branch", "b", "", "Branch to deploy")
 	deployCmd.Flags().StringVarP(&pipelineFlag, "pipeline", "p", "", "Pipeline to deploy (production or staging)")
-
+	deployCmd.Flags().BoolVarP(&currentFlag, "current", "c", false, "Use the current Git branch for deployment")
 	rootCmd.AddCommand(deployCmd)
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -42,16 +42,18 @@ var deployCmd = &cobra.Command{
 		}
 
 		if currentFlag {
-			branch, err = util.GetBranch()
+			branch, project, err = util.GetBranchAndDirectory()
 			if err != nil {
 				log.Fatalf("Error: %v", err)
 			}
-			log.Printf("Using current branch: %s\n", branch)
+			log.Printf("Using current project %s and branch: %s\n", project, branch)
 		}
 
-		if len(args) > 0 {
-			project = args[0]
-			fmt.Printf("Looking up project passed as argument: %s\n", project)
+		if len(args) > 0 || (currentFlag && project != "") {
+			if project == "" {
+				project = args[0]
+			}
+			fmt.Printf("Looking up project: %s\n", project)
 			projectFound, err := apiClient.FetchProjectByName(project)
 			if err != nil {
 				log.Fatalf("Error: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ var rootCmd = &cobra.Command{
 	It allows users to manage and run pipelines for continuous integration (CI) and continuous deployment (CD).
 	With this tool, you can easily deploy to staging or production environments, ensuring a smooth and automated
 	workflow for your development and deployment processes.`,
+	Version: "1.1.0",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/client.go
+++ b/internal/client.go
@@ -168,21 +168,11 @@ func (c *BuddyClient) FetchBranchByName(project, branch string) (*Branch, *Error
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, &ErrorResponse{
-			Errors: []ErrorDetail{
-				{
-					Message: fmt.Sprintf("Branch %s not found in project %s", branch, project),
-				},
-			},
-		}
-	}
-
 	if resp.StatusCode != http.StatusOK {
 		return nil, &ErrorResponse{
 			Errors: []ErrorDetail{
 				{
-					Message: fmt.Sprintf("Error fetching branch: %s", resp.Status),
+					Message: fmt.Sprintf("Branch %s not found in project %s", branch, project),
 				},
 			},
 		}

--- a/internal/interface.go
+++ b/internal/interface.go
@@ -20,7 +20,7 @@ type ProjectResponse struct {
 	Projects []Project `json:"projects"` // This contains the array of Project objects
 }
 
-// The Project struct that you already have
+// The Project struct
 type Project struct {
 	Name        string `json:"name"`
 	DisplayName string `json:"display_name"`
@@ -45,7 +45,7 @@ type Branch struct {
 type PipelineResponse struct {
 	URL       string     `json:"url"`
 	HTMLURL   string     `json:"html_url"`
-	Pipelines []Pipeline `json:"pipelines"` // This contains the array of Pipeline objects
+	Pipelines []Pipeline `json:"pipelines"`
 }
 
 // Pipeline struct to represent an individual Git branch

--- a/internal/util/git.go
+++ b/internal/util/git.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// checkIfGitRepo checks if the current directory is a Git repository
+func checkIfGitRepo() bool {
+	// Try running 'git rev-parse --is-inside-work-tree'
+	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) == "true"
+}
+
+// getCurrentBranch retrieves the current Git branch in the repository
+func getCurrentBranch() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("not a git repository or no branch: %v", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func GetBranch() (string, error) {
+	if !checkIfGitRepo() {
+		return "", fmt.Errorf("not a git repository")
+	}
+	return getCurrentBranch()
+}

--- a/internal/util/git.go
+++ b/internal/util/git.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -32,4 +34,39 @@ func GetBranch() (string, error) {
 		return "", fmt.Errorf("not a git repository")
 	}
 	return getCurrentBranch()
+}
+
+func GetLocal() (string, error) {
+	if !checkIfGitRepo() {
+		return "", fmt.Errorf("not a git repository")
+	}
+	return GetCurrentDirectoryName()
+}
+
+// GetBranchAndDirectory returns the current branch and directory name
+func GetBranchAndDirectory() (string, string, error) {
+	if !checkIfGitRepo() {
+		return "", "", fmt.Errorf("not a git repository")
+	}
+	branch, err := getCurrentBranch()
+	if err != nil {
+		return "", "", err
+	}
+	directory, err := GetCurrentDirectoryName()
+	if err != nil {
+		return "", "", err
+	}
+	return branch, directory, nil
+}
+
+// GetCurrentDirectoryName returns the name of the current directory
+func GetCurrentDirectoryName() (string, error) {
+	// Get the current working directory
+	currentPath, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	// Extract the base (last element) of the path
+	return filepath.Base(currentPath), nil
 }


### PR DESCRIPTION
updated config structs and logic to bypass certain prompts if branch is valid

Next Todo: Pick up curent project from same -c flag
