### PR TITLE
feat: Add a last deploy status (subcommand)

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -189,11 +189,60 @@ var deployCmd = &cobra.Command{
 	},
 }
 
+// statusCmd represents the status subcommand
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check the status of the last deployment",
+	Long:  `This subcommand allows you to check the status of the last deployment, including the time it happened and who triggered it.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var pipeline buddy.Pipeline
+		config, err := loadConfig()
+		if err != nil {
+			log.Fatalf("Failed to load configuration: %v\n", err)
+		}
+
+		apiClient := buddy.NewBuddyClient(config.Token, config.Workspace)
+
+		projects, err := apiClient.FetchProjects()
+		if err != nil {
+			log.Fatalf("Error fetching projects 2: %v", err)
+		}
+		project := searchProject(projects)
+
+		pipelines, err := apiClient.FetchPipelines(project)
+		if err != nil {
+			log.Fatalf("Error fetching pipelines: %v", err)
+		}
+		pipeline = searchPipeline(pipelines, "")
+
+		executions, err := apiClient.FetchExecutions(project, pipeline.ID)
+		if err != nil {
+			log.Fatalf("Error fetching executions: %v", err)
+		}
+		if len(executions.Executions) == 0 {
+			log.Fatalln("No executions found")
+		}
+		lastExecution := executions.Executions[0]
+
+		c := color.New(color.FgHiWhite, color.Bold)
+		bg := c.Add(color.BgHiGreen).SprintFunc()
+
+		fmt.Printf("Last deployment status: %s\n", bg(lastExecution.Status))
+		fmt.Printf("Last deployment was triggered on: %s\n", bg(convertToLocalTime(lastExecution.StartDate)))
+		fmt.Printf("Last deployment completed on: %s\n", bg(convertToLocalTime(lastExecution.FinishDate)))
+		fmt.Printf("Last deployment was triggered by: %s\n", bg(lastExecution.Creator.Name))
+	},
+}
+
 func init() {
 	// Add branch and pipeline flags
 	deployCmd.Flags().StringVarP(&branchFlag, "branch", "b", "", "Branch to deploy")
 	deployCmd.Flags().StringVarP(&pipelineFlag, "pipeline", "p", "", "Pipeline to deploy (production or staging)")
 	deployCmd.Flags().BoolVarP(&currentFlag, "current", "c", false, "Use the current Git branch for deployment")
+
+	// Add the status subcommand to the deploy command
+	deployCmd.AddCommand(statusCmd)
+
 	rootCmd.AddCommand(deployCmd)
 }
 
@@ -344,4 +393,15 @@ func checkStatus() (bool, error) {
 // Helper function to do case-insensitive search
 func containsIgnoreCase(str, substr string) bool {
 	return strings.Contains(strings.ToLower(str), strings.ToLower(substr))
+}
+
+func convertToLocalTime(utcTime string) string {
+	// Parse the time string
+	t, err := time.Parse(time.RFC3339, utcTime)
+	if err != nil {
+		log.Fatalf("Error parsing time: %v", err)
+	}
+	// Convert to local time
+	localTime := t.Local()
+	return localTime.Format(time.RFC1123)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ var rootCmd = &cobra.Command{
 	It allows users to manage and run pipelines for continuous integration (CI) and continuous deployment (CD).
 	With this tool, you can easily deploy to staging or production environments, ensuring a smooth and automated
 	workflow for your development and deployment processes.`,
-	Version: "1.1.0",
+	Version: "1.3.0",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/client.go
+++ b/internal/client.go
@@ -355,3 +355,39 @@ func (c *BuddyClient) CheckPipelineStatus(project string, pipeline int, executio
 
 	return &executionResponse.Status, nil
 }
+
+// FetchExecutions fetches the executions of a pipeline
+func (c *BuddyClient) FetchExecutions(project string, pipelineID int) (*ExecutionsResponse, error) {
+	client := &http.Client{}
+	url := fmt.Sprintf("https://api.buddy.works/workspaces/%s/projects/%s/pipelines/%d/executions", c.Workspace, project, pipelineID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error fetching pipelines: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var executionsResponse ExecutionsResponse
+	err = json.Unmarshal(body, &executionsResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &executionsResponse, nil
+}

--- a/internal/interface.go
+++ b/internal/interface.go
@@ -50,12 +50,15 @@ type PipelineResponse struct {
 
 // Pipeline struct to represent an individual Git branch
 type Pipeline struct {
-	URL      string   `json:"url"`
-	HTMLURL  string   `json:"html_url"`
-	ID       int      `json:"id"`
-	Name     string   `json:"name"`
-	Priority string   `json:"priority,omitempty"`
-	Refs     []string `json:"refs,omitempty"`
+	URL                 string   `json:"url"`
+	HTMLURL             string   `json:"html_url"`
+	ID                  int      `json:"id"`
+	Name                string   `json:"name"`
+	Priority            string   `json:"priority,omitempty"`
+	Refs                []string `json:"refs,omitempty"`
+	LastExecutionStatus string   `json:"last_execution_status,omitempty"`
+	CreateDate          string   `json:"create_date,omitempty"`
+	Creator             Creator  `json:"creator,omitempty"`
 }
 
 // Committer represents the committer object
@@ -117,6 +120,34 @@ type PipelineExecutionResponse struct {
 	Creator      Creator  `json:"creator"`
 	Pipeline     Pipeline `json:"pipeline"`
 	// ActionExecutions []ActionExecution `json:"action_executions"`
+}
+
+type ExecutionsResponse struct {
+	URL               string      `json:"url"`
+	Page              int         `json:"page"`
+	PageSize          int         `json:"page_size"`
+	TotalPageCount    int         `json:"total_page_count"`
+	ElementCount      int         `json:"element_count"`
+	TotalElementCount int         `json:"total_element_count"`
+	Executions        []Execution `json:"executions"`
+}
+
+type Execution struct {
+	URL          string   `json:"url"`
+	HTMLURL      string   `json:"html_url"`
+	ID           int      `json:"id"`
+	StartDate    string   `json:"start_date"`
+	FinishDate   string   `json:"finish_date"`
+	TriggeredOn  string   `json:"triggered_on"`
+	Priority     string   `json:"priority"`
+	Refresh      bool     `json:"refresh"`
+	ClearCache   bool     `json:"clear_cache"`
+	Status       string   `json:"status"`
+	Comment      string   `json:"comment"`
+	Branch       Branch   `json:"branch"`
+	FromRevision Revision `json:"from_revision"`
+	ToRevision   Revision `json:"to_revision"`
+	Creator      Creator  `json:"creator"`
 }
 
 type ErrorDetail struct {


### PR DESCRIPTION
This pull request introduces a new feature to check the status of the last deployment and includes various supporting changes to the codebase. The most important changes are the addition of the `status` subcommand, the implementation of the `FetchExecutions` method, and updates to the `Pipeline` and `Execution` structs.

### New Feature: Deployment Status Check

* [`cmd/deploy.go`](diffhunk://#diff-e61f952a089e5960dd93ef2a48a83b1187c9700efabc40974fb9f2d9b50b4a7eR192-R245): Added a new `status` subcommand to the `deploy` command, which allows users to check the status of the last deployment. This includes details such as the time it happened and who triggered it.
* [`cmd/deploy.go`](diffhunk://#diff-e61f952a089e5960dd93ef2a48a83b1187c9700efabc40974fb9f2d9b50b4a7eR397-R407): Implemented the `convertToLocalTime` function to convert UTC time to local time for display purposes.

### API Client Enhancements

* [`internal/client.go`](diffhunk://#diff-1936beeebc5541ea03b5fd0abdb15dac2ece8a4e8ea24b1ec29ac8b24fd6e4d2R358-R393): Added the `FetchExecutions` method to the `BuddyClient` struct to fetch the executions of a pipeline from the Buddy API.

### Data Structure Updates

* [`internal/interface.go`](diffhunk://#diff-396b4c151f5a1d62947dd1696ef3d56143e8a03e8770b817f6d7537846609277R59-R61): Updated the `Pipeline` struct to include fields for `LastExecutionStatus`, `CreateDate`, and `Creator`.
* [`internal/interface.go`](diffhunk://#diff-396b4c151f5a1d62947dd1696ef3d56143e8a03e8770b817f6d7537846609277R125-R152): Added new structs `ExecutionsResponse` and `Execution` to represent the response and individual execution details from the Buddy API.

### Version Update

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL17-R17): Updated the version of the CLI tool from `1.1.0` to `1.3.0` to reflect the new feature addition.